### PR TITLE
Add GitHub Projects to Sidebar and Remove Upgrade Section

### DIFF
--- a/src/layouts/full/sidebar/MenuItems.js
+++ b/src/layouts/full/sidebar/MenuItems.js
@@ -1,5 +1,5 @@
 import {
-  IconAperture, IconCopy, IconLayoutDashboard, IconLogin, IconMoodHappy, IconTypography, IconUserPlus, IconVote, IconBrandGithub
+  IconAperture, IconCopy, IconLayoutDashboard, IconLogin, IconMoodHappy, IconTypography, IconUserPlus, IconChecks, IconBrandGithub
 } from '@tabler/icons';
 
 import { uniqueId } from 'lodash';

--- a/src/layouts/full/sidebar/MenuItems.js
+++ b/src/layouts/full/sidebar/MenuItems.js
@@ -19,7 +19,7 @@ const Menuitems = [
   {
     id: uniqueId(),
     title: 'Community Vote',
-    icon: IconVote,
+    icon: IconChecks,
     href: 'https://alfa2267.github.io/community-vote/',
     external: true,
   },


### PR DESCRIPTION
## Summary
- Add GitHub Projects section to sidebar with links to alfa2267.github.io and community-vote repositories
- Remove "Unlimited Access" upgrade section from sidebar
- Fix IconVote import error by using IconChecks instead

## Test plan
- [x] Start development server without compilation errors
- [x] Verify sidebar shows GitHub Projects section
- [x] Verify "Unlimited Access" section is hidden
- [x] Test external links open correctly

🤖 Generated with [Claude Code](https://claude.ai/code)