### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/src/services/github.js
+++ b/src/services/github.js
@@ -66,7 +66,7 @@ class GitHubService {
       const html = await response.text();
       return html;
     } catch (error) {
-      console.error(`Error fetching README HTML for ${repoName}:`, error);
+      console.error('Error fetching README HTML for %s:', repoName, error);
       return null;
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/alfa2267/alfa2267.github.io/security/code-scanning/1](https://github.com/alfa2267/alfa2267.github.io/security/code-scanning/1)

To fix the problem, we should avoid passing user-controlled data directly as part of a format string to logging functions. Instead, we should use a static format string and pass the user-controlled value as a separate argument. In this case, we can change the call from:

```js
console.error(`Error fetching README HTML for ${repoName}:`, error);
```

to:

```js
console.error('Error fetching README HTML for %s:', repoName, error);
```

This ensures that any format specifiers in `repoName` are not interpreted by the logging function, and the value is safely inserted as a string. No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
